### PR TITLE
Update webapp manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,22 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "run.rb",
+  "name": "run.rb - Runner Bee",
   "icons": [
+    {
+        "src": "apple-touch-icon.png",
+        "sizes": "180x180",
+        "type": "image/png"
+    },
+    {
+        "src": "favicon-32x32.png",
+        "sizes": "32x32",
+        "type": "image/png"
+    },
+    {
+        "src": "favicon-16x16.png",
+        "sizes": "16x16",
+        "type": "image/png"
+    },
     {
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
@@ -10,6 +25,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#ff7474",
   "background_color": "#ffffff"
 }


### PR DESCRIPTION
This updates the default values in the webapp manifest. In browsers that respect the manifest (Chrome, Firefox), this improves the experience slightly. The app can be added to the homescreen/desktop and will use a nice icon, name, and theme color.

I'd be happy to update any of these values if they're not suitable. I just used the values I found in <head> for the icons and the CSS link color for theme color.